### PR TITLE
Guard Monri initialization before payment calls

### DIFF
--- a/android/src/main/java/com/monri/flutter/MonriPaymentsPlugin.java
+++ b/android/src/main/java/com/monri/flutter/MonriPaymentsPlugin.java
@@ -69,12 +69,14 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     private static final String ERROR_INVALID_IMAGES = "INVALID_IMAGES";
     private static final String ERROR_EXTRACTION = "EXTRACTION_ERROR";
     private static final String ERROR_VALIDATION = "VALIDATION_ERROR";
+    private static final String ERROR_MONRI_UNAVAILABLE = "MONRI_UNAVAILABLE";
 
     // Error messages
     private static final String MSG_ARGS_MUST_BE_MAP = "Arguments must be a map";
     private static final String MSG_MISSING_BASE64_IMG = "Missing base64Img";
     private static final String MSG_MISSING_BASE64_IMGS = "Missing base64Imgs";
     private static final String MSG_FAILED_DECODE_BITMAP = "Failed to decode base64 to bitmap";
+    private static final String MSG_MONRI_UNAVAILABLE = "Monri SDK is not initialized yet. Please retry payment.";
 
     private MethodChannel channel;
     private Boolean devMode = true;
@@ -90,6 +92,20 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
         if (activity != null && monri == null) {
             monri = new Monri((ActivityResultCaller) this.activity);
         }
+    }
+
+    private Monri ensureMonriOrReport(MethodChannel.Result result) {
+        if (monri != null) {
+            return monri;
+        }
+
+        initMonri();
+        if (monri != null) {
+            return monri;
+        }
+
+        result.error(ERROR_MONRI_UNAVAILABLE, MSG_MONRI_UNAVAILABLE, null);
+        return null;
     }
 
     @Override
@@ -110,15 +126,19 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     }
 
     private void monriConfirmPayment(final Object arguments, final MethodChannel.Result result) {
+        final Monri monriInstance = ensureMonriOrReport(result);
+        if (monriInstance == null) {
+            return;
+        }
 
         final FlutterConfirmPaymentParams flutterConfirmPaymentParams = new MonriConverter(arguments).process();
         final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams();
 
         MonriPaymentsPlugin.writeMetaData(this.activity, String.format("Android-SDK:Flutter:%s", BuildConfig.MONRI_FLUTTER_PLUGIN_VERSION));
 
-        monri.setMonriApiOptions(flutterConfirmPaymentParams.monriApiOptions());
+        monriInstance.setMonriApiOptions(flutterConfirmPaymentParams.monriApiOptions());
 
-        this.monri.confirmPayment(confirmPaymentParams, (paymentResult, throwable) -> {
+        monriInstance.confirmPayment(confirmPaymentParams, (paymentResult, throwable) -> {
             if (throwable != null) {
                 result.error("payment_error", throwable.getMessage(), null);
                 return;
@@ -131,19 +151,23 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     }
 
     private void confirmGooglePayPayment(Object arguments, MethodChannel.Result result) {
+        final Monri monriInstance = ensureMonriOrReport(result);
+        if (monriInstance == null) {
+            return;
+        }
 
         final FlutterConfirmPaymentParams flutterConfirmPaymentParams = new MonriConverter(arguments).process();
         final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams();
 
         MonriPaymentsPlugin.writeMetaData(this.activity, String.format("Android-SDK:Flutter:%s", BuildConfig.MONRI_FLUTTER_PLUGIN_VERSION));
 
-        monri.setMonriApiOptions(flutterConfirmPaymentParams.monriApiOptions());
+        monriInstance.setMonriApiOptions(flutterConfirmPaymentParams.monriApiOptions());
 
         final FlutterConfirmPaymentParams.FlutterGooglePay gPayParams = flutterConfirmPaymentParams.getGooglePayData();
 
         final GooglePayButtonOptions googlePayButtonOptions = new GooglePayButtonOptions(gPayParams.gPayButtonType, gPayParams.gPayTheme, gPayParams.gPayCornerRadius);
 
-        this.monri.confirmPayment(confirmPaymentParams, (paymentResult, throwable) -> {
+        monriInstance.confirmPayment(confirmPaymentParams, (paymentResult, throwable) -> {
             if (throwable != null) {
                 result.error("payment_error", throwable.getMessage(), null);
                 return;
@@ -217,6 +241,9 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     }
 
     private static void writeMetaData(Context context, String library) {
+        if (context == null) {
+            return;
+        }
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         sharedPreferences.edit().putString("com.monri.meta.library", library).apply();
     }


### PR DESCRIPTION
## Summary
- Fixes a crash where Android release builds can throw `Attempt to invoke virtual method 'void com.monri.android.Monri.setMonriApiOptions(...)' on a null object reference` from `MonriPaymentsPlugin`.
- Adds a safe runtime guard that re-initializes `Monri` at payment call time (`confirmPayment` and `confirmGooglePayment`) and returns a controlled platform error if `Monri` still cannot be initialized.
- Keeps existing payment behavior unchanged when initialization succeeds.

## Root Cause
`MonriPaymentsPlugin` stores `Monri` as a nullable field and initializes it in `onAttachedToActivity` (`initMonri()`).

However, the plugin also nulls it during detach:
- `onDetachedFromActivity()` -> `tearDown()` -> `monri = null`

Payment entry points then use `monri` directly without a null-check:
- `monri.setMonriApiOptions(...)`
- `monri.confirmPayment(...)`

If a method-channel payment call lands while the plugin is between activity binding states (or `monri` was nulled and not reinitialized yet), this produces a NullPointerException.

## Why this appears mostly in release
Release timing/optimization tends to make this easier to hit, but the underlying issue is lifecycle null-safety in plugin code, not business logic in integrating apps.

## Reproduction (one way)
1. Integrate this plugin in a Flutter app with Android release build (`minifyEnabled true` often makes this surface faster).
2. Start card payment flow.
3. Trigger an activity lifecycle transition around payment (e.g. config-change / activity rebinding / return from an external UI path).
4. Submit payment quickly after rebinding window.
5. Observe crash in plugin at `setMonriApiOptions` because `monri` is null.

## Fix details
- Added `ensureMonriOrReport(Result result)`:
  - returns existing `monri` if available,
  - otherwise calls `initMonri()` and retries,
  - if still null, returns `result.error("MONRI_UNAVAILABLE", ...)` and aborts gracefully.
- Applied the guard at the start of:
  - `monriConfirmPayment(...)`
  - `confirmGooglePayPayment(...)`
- Added null check in `writeMetaData(...)` to avoid potential context-related NPE on edge lifecycle timing.

## Backward compatibility
- No API surface changes.
- No change to successful payment flow semantics.
- Only replaces a hard crash with an explicit platform error in lifecycle edge cases.

## Test Plan
- [x] Build and run plugin with patched Android Java code.
- [x] Verify branch diff is scoped to `MonriPaymentsPlugin.java` only.
- [x] Confirm normal success path remains unchanged (same Monri calls, same mapping).
- [x] Confirm null lifecycle edge now short-circuits with controlled error instead of NPE.

Made with [Cursor](https://cursor.com)