### PR TITLE
update native SDKs and add browser info to confirm payment params

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ android {
 
 dependencies {
 //    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.monri:monri-android:3.2.0'
+    implementation 'com.monri:monri-android:3.2.2'
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'com.google.android.gms:play-services-wallet:19.5.0'
 }

--- a/android/src/main/java/com/monri/flutter/FlutterConfirmPaymentParams.java
+++ b/android/src/main/java/com/monri/flutter/FlutterConfirmPaymentParams.java
@@ -1,5 +1,8 @@
 package com.monri.flutter;
 
+import android.content.Context;
+
+import com.monri.android.model.BrowserInfo;
 import com.monri.android.model.Card;
 import com.monri.android.model.ConfirmPaymentParams;
 import com.monri.android.model.CustomerParams;
@@ -69,8 +72,9 @@ public class FlutterConfirmPaymentParams {
         return rv;
     }
 
-    ConfirmPaymentParams confirmPaymentParams() {
-        return ConfirmPaymentParams.create(clientSecret, paymentMethodParams(), transactionParams());
+    ConfirmPaymentParams confirmPaymentParams(final Context context) {
+        return ConfirmPaymentParams.create(clientSecret, paymentMethodParams(), transactionParams())
+                                   .setBrowserInfo(BrowserInfo.create(context));
     }
 
     MonriApiOptions monriApiOptions() {

--- a/android/src/main/java/com/monri/flutter/MonriPaymentsPlugin.java
+++ b/android/src/main/java/com/monri/flutter/MonriPaymentsPlugin.java
@@ -112,7 +112,7 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     private void monriConfirmPayment(final Object arguments, final MethodChannel.Result result) {
 
         final FlutterConfirmPaymentParams flutterConfirmPaymentParams = new MonriConverter(arguments).process();
-        final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams();
+        final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams(this.activity.getApplicationContext());
 
         MonriPaymentsPlugin.writeMetaData(this.activity, String.format("Android-SDK:Flutter:%s", BuildConfig.MONRI_FLUTTER_PLUGIN_VERSION));
 
@@ -133,7 +133,7 @@ public class MonriPaymentsPlugin implements FlutterPlugin, MethodCallHandler, Ac
     private void confirmGooglePayPayment(Object arguments, MethodChannel.Result result) {
 
         final FlutterConfirmPaymentParams flutterConfirmPaymentParams = new MonriConverter(arguments).process();
-        final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams();
+        final ConfirmPaymentParams confirmPaymentParams = flutterConfirmPaymentParams.confirmPaymentParams(this.activity.getApplicationContext());
 
         MonriPaymentsPlugin.writeMetaData(this.activity, String.format("Android-SDK:Flutter:%s", BuildConfig.MONRI_FLUTTER_PLUGIN_VERSION));
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'Monri', '~> 2.3.2'
+  pod 'Monri', '~> 2.3.4'
   pod 'Alamofire', '~> 5.10.2'
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,11 +3,11 @@ PODS:
   - camera_avfoundation (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - Monri (2.3.3):
+  - Monri (2.3.4):
     - Alamofire (~> 5.10.2)
   - MonriPayments (1.3.1):
     - Flutter
-    - Monri (~> 2.3.2)
+    - Monri (~> 2.3.4)
   - permission_handler_apple (9.3.0):
     - Flutter
 
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - Alamofire (~> 5.10.2)
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
-  - Monri (~> 2.3.2)
+  - Monri (~> 2.3.4)
   - MonriPayments (from `.symlinks/plugins/MonriPayments/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
@@ -38,10 +38,10 @@ SPEC CHECKSUMS:
   Alamofire: 7193b3b92c74a07f85569e1a6c4f4237291e7496
   camera_avfoundation: 5675ca25298b6f81fa0a325188e7df62cc217741
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Monri: 585f4b30ef76c21707d6d93c1b817e3204efdea5
-  MonriPayments: 19965847b8bf469a11f28bdc6935bd9bb843a39c
+  Monri: 1ba144954962eff24507be3bdf36482d2473e872
+  MonriPayments: 6e8edb4a096dc79355ed436147521d26cf752482
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
 
-PODFILE CHECKSUM: 5441c02e6744ed3622a8a6b32b154b40911beff3
+PODFILE CHECKSUM: fa230e7582fa0f9f5d1d1c9bd25a0cecd8a042ea
 
 COCOAPODS: 1.16.2

--- a/ios/Classes/FlutterConfirmPaymentParams.swift
+++ b/ios/Classes/FlutterConfirmPaymentParams.swift
@@ -83,7 +83,10 @@ class FlutterConfirmPaymentParams {
     }
     
     func confirmPaymentParams() -> ConfirmPaymentParams {
-        return ConfirmPaymentParams(paymentId: clientSecret, paymentMethod: paymentMethodParams(), transaction: buildMonriTransactionParams())
+        return ConfirmPaymentParams(paymentId: clientSecret,
+                                    paymentMethod: paymentMethodParams(),
+                                    transaction: buildMonriTransactionParams(),
+                                    browserInfo: BrowserInfo.create())
     }
     
     static func create(request: Dictionary<String, AnyObject?>, card: FlutterCard?, savedCard: FlutterSavedCard?) -> FlutterConfirmPaymentParams {

--- a/ios/MonriPayments.podspec
+++ b/ios/MonriPayments.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Monri', '~> 2.3.2'
+  s.dependency 'Monri', '~> 2.3.4'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: MonriPayments
 description: Monri flutter plugin project.
-version: 1.3.1
+version: 1.3.2
 homepage: monri.com
 
 environment:


### PR DESCRIPTION
- Bump monri-android 3.2.0 -> 3.2.2
- Bump Monri iOS pod ~> 2.3.2 -> ~> 2.3.4
- Attach BrowserInfo to ConfirmPaymentParams on both platforms (3DS2 flow)